### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/profiles/1_not_ready/driver/displaylink.nix
+++ b/profiles/1_not_ready/driver/displaylink.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }: {
 
   # Displaylink driver for multiple monitors
-  # See more at https://nixos.wiki/wiki/Displaylink
+  # See more at https://wiki.nixos.org/wiki/Displaylink
 
   # Remember to add the drivers to the nix store
   # https://www.synaptics.com/products/displaylink-graphics/downloads/ubuntu

--- a/profiles/audio/pipewire.nix
+++ b/profiles/audio/pipewire.nix
@@ -12,8 +12,8 @@ in {
     config = mkIf cfg.pipewire {
 
         # Pipewire audio configuration.
-        # See more at https://nixos.wiki/wiki/Pipewire
-        # See more at https://nixos.wiki/wiki/PulseAudio
+        # See more at https://wiki.nixos.org/wiki/Pipewire
+        # See more at https://wiki.nixos.org/wiki/PulseAudio
 
         sound.enable = true;
         users.users.${user}.extraGroups = [ "audio" ];

--- a/profiles/services/wine.nix
+++ b/profiles/services/wine.nix
@@ -14,7 +14,7 @@ in {
     config = mkIf cfg.enable {
 
         # Wine configuration and packages
-        # See more at https://nixos.wiki/wiki/Wine
+        # See more at https://wiki.nixos.org/wiki/Wine
 
         # Support for 32-bit apps.
         # Only supported for nvidia and also Mesa.

--- a/profiles/systemd/old/previous/cron.nix
+++ b/profiles/systemd/old/previous/cron.nix
@@ -4,7 +4,7 @@
   ...
 }: {
   # Cron is now deprecated, but you can still use it.
-  # https://nixos.wiki/wiki/Cron
+  # https://wiki.nixos.org/wiki/Cron
 
   services.cron = {
     enable = true;


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️